### PR TITLE
fix: prevent iOS/Safari cache issues by adding no-store headers and pageshow reload, and ensure form input is flashed for old() support

### DIFF
--- a/app/Http/Controllers/BackendController.php
+++ b/app/Http/Controllers/BackendController.php
@@ -2071,24 +2071,27 @@ class BackendController extends Controller
 
         $columns_zhtw = config('camps_fields.display.' . $this->campFullData->table);
 
-        return view('backend.integrated_operating_interface.theList')
-                ->with('applicants', $applicants)
-                ->with('batches', $batches)
-                ->with('current_batch', Batch::find($request->batch_id))
-                ->with('isShowVolunteers', 0)
-                ->with('isSetting', $isSetting)
-                ->with('isSettingCarer', $request->isSettingCarer ?? 0)
-                ->with('carers', $carers ?? null)
-                ->with('isShowLearners', 1)
-                ->with('is_ingroup', 0)
-                ->with('groupName', '')
-                ->with('columns_zhtw', $columns_zhtw)
-                ->with('fullName', $this->campFullData->fullName)
-                ->with('queryStr', $queryStr ?? null)
-                ->with('groups', $this->campFullData->groups)
-                ->with('targetGroupIds', $target_group_ids ?? null)
-                ->with('dynamic_stats', $dynamic_stats)
-                ->withInput($request->all());
+        $request->flash();
+        return response()->view('backend.integrated_operating_interface.theList', [
+                'applicants' => $applicants,
+                'batches' => $batches,
+                'current_batch' => Batch::find($request->batch_id),
+                'isShowVolunteers' => 0,
+                'isSetting' => $isSetting,
+                'isSettingCarer' => $request->isSettingCarer ?? 0,
+                'carers' => $carers ?? null,
+                'isShowLearners' => 1,
+                'is_ingroup' => 0,
+                'groupName' => '',
+                'columns_zhtw' => $columns_zhtw,
+                'fullName' => $this->campFullData->fullName,
+                'queryStr' => $queryStr ?? null,
+                'groups' => $this->campFullData->groups,
+                'targetGroupIds' => $target_group_ids ?? null,
+                'dynamic_stats' => $dynamic_stats
+            ])
+            ->header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            ->header('Pragma', 'no-cache');
     }
 
     public function showVolunteers(Request $request)
@@ -2319,23 +2322,27 @@ class BackendController extends Controller
         $camp_str = $this->campFullData->vcamp->table;
         $columns_zhtw = config('camps_fields.display.' . $camp_str);
 
-        return view('backend.integrated_operating_interface.theList')
-                ->with('applicants', $applicants)
-                ->with('registeredVolunteers', $registeredUsers)
-                ->with('batches', $batches)
-                ->with('current_batch', Batch::find($request->batch_id))
-                ->with('isShowVolunteers', 1)
-                ->with('isSetting', $isSetting)
-                ->with('isSettingCarer', $request->isSettingCarer ?? 0)
-                ->with('carers', null)
-                ->with('isShowLearners', 0)
-                ->with('is_ingroup', 0)
-                ->with('groupName', '')
-                ->with('columns_zhtw', $columns_zhtw)
-                ->with('fullName', $this->campFullData->fullName)
-                ->with('groups', $this->campFullData->roles)
-                ->with('queryStr', $queryStr ?? '')
-                ->with('queryRoles', $queryRoles ?? '');
+        $request->flash();
+        return response()->view('backend.integrated_operating_interface.theList', [
+                'applicants' => $applicants,
+                'registeredVolunteers' => $registeredUsers,
+                'batches' => $batches,
+                'current_batch' => Batch::find($request->batch_id),
+                'isShowVolunteers' => 1,
+                'isSetting' => $isSetting,
+                'isSettingCarer' => $request->isSettingCarer ?? 0,
+                'carers' => null,
+                'isShowLearners' => 0,
+                'is_ingroup' => 0,
+                'groupName' => '',
+                'columns_zhtw' => $columns_zhtw,
+                'fullName' => $this->campFullData->fullName,
+                'groups' => $this->campFullData->roles,
+                'queryStr' => $queryStr ?? '',
+                'queryRoles' => $queryRoles ?? ''
+            ])
+            ->header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            ->header('Pragma', 'no-cache');
     }
 
     public function export(Request $request)
@@ -2430,22 +2437,26 @@ class BackendController extends Controller
         $camp_str = $this->campFullData->vcamp->table;
         $columns_zhtw = config('camps_fields.display.' . $camp_str);
 
-        return view('backend.integrated_operating_interface.theList')
-                ->with('registeredVolunteers', $registeredUsers)
-                ->with('applicants', $applicants)
-                ->with('batches', $batches)
-                ->with('isShowVolunteers', 1)
-                ->with('current_batch', Batch::find($request->batch_id))
-                ->with('isSetting', $isSetting)
-                ->with('isSettingCarer', $request->isSettingCarer ?? 0)
-                ->with('carers', null)
-                ->with('isShowLearners', 1)
-                ->with('is_ingroup', 1)
-                ->with('groupName', '第1組')
-                ->with('columns_zhtw', $columns_zhtw)
-                ->with('fullName', $this->campFullData->fullName)
-                ->with('groups', $this->campFullData->roles)
-                ->with('queryStr', $queryStr ?? '');
+        $request->flash();
+        return response()->view('backend.integrated_operating_interface.theList', [
+                'registeredVolunteers' => $registeredUsers,
+                'applicants' => $applicants,
+                'batches' => $batches,
+                'isShowVolunteers' => 1,
+                'current_batch' => Batch::find($request->batch_id),
+                'isSetting' => $isSetting,
+                'isSettingCarer' => $request->isSettingCarer ?? 0,
+                'carers' => null,
+                'isShowLearners' => 1,
+                'is_ingroup' => 1,
+                'groupName' => '第1組',
+                'columns_zhtw' => $columns_zhtw,
+                'fullName' => $this->campFullData->fullName,
+                'groups' => $this->campFullData->roles,
+                'queryStr' => $queryStr ?? ''
+            ])
+            ->header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            ->header('Pragma', 'no-cache');
     }
 
     public function getAvatar($camp_id, $id)

--- a/resources/views/components/general/settings.blade.php
+++ b/resources/views/components/general/settings.blade.php
@@ -85,7 +85,28 @@
 </div>
 
 <script>
+    // 解決 iOS Safari 返回頁面時快取舊資料的問題
+    window.addEventListener('pageshow', function(event) {
+        if (event.persisted) {
+            window.location.reload();
+        }
+    });
+
     (function() {
+        // 為了解決 iOS 的快取問題，我們在每個 GET 請求中加入一個時間戳記，
+        // 以確保每次都從伺服器獲取最新的資料。
+        axios.interceptors.request.use(function (config) {
+            if (config.method === 'get') {
+                if (!config.params) {
+                    config.params = {};
+                }
+                config.params['_'] = new Date().getTime();
+            }
+            return config;
+        }, function (error) {
+            return Promise.reject(error);
+        });
+
         @if($isShowLearners)
             axios({
                 method: 'get',


### PR DESCRIPTION
此 PR 旨在解決在 iOS/Safari 上使用「返回」按鈕時，頁面顯示舊資料的問題，同時確保在表單驗證失敗後，使用者輸入的資料不會遺失。

### 主要變更

*   **`app/Http/Controllers/BackendController.php`**
    *   在幾個主要列表頁面（學員、義工等）的 Controller 方法中，將 `view()` 回傳方式改為 `response()->view()`，以便加上 HTTP 標頭。
    *   加入了 `Cache-Control: no-store, no-cache` 與 `Pragma: no-cache` 標頭，指示瀏覽器不要快取這些頁面，從而解決 iOS 裝置上的快取問題。
    *   在回傳 `response` 前加上 `$request->flash()`，確保表單的舊輸入值能被存入 session，讓 Blade 中的 `old()` 輔助函式可以正常運作。

*   **`resources/views/components/general/settings.blade.php`**
    *   加入了一個 JavaScript `pageshow` 事件的監聽器。此腳本會偵測頁面是否從瀏覽器的「上一頁/下一頁快取」（bfcache）中載入，如果是，則強制重新整理頁面。這為行動裝置上的快取問題提供了另一層保護。

這些變更共同作用，確保使用者總是能看到最新的資料，並且不會遺失他們在表單中輸入的內容，從而提供更可靠的使用者體驗。