### PR TITLE
make name changeable

### DIFF
--- a/resources/views/camps/tcamp/form.blade.php
+++ b/resources/views/camps/tcamp/form.blade.php
@@ -64,9 +64,6 @@ header("Expires: Fri, 01 Jan 1990 00:00:00 GMT");
     <div class='row form-group required'>
         <label for='inputName' class='col-md-2 control-label text-md-right'>姓名</label>
         <div class='col-md-10'>
-            <!--
-            <input type='text' name='name' value='' class='form-control' id='inputName' placeholder='請填寫全名' required @if(isset($isModify) && $isModify) disabled @endif>
-            -->
             <input required type='text' name='name' value='' class='form-control' id='inputName' placeholder='請填寫全名'>
             <div class="invalid-feedback">
                 未填寫姓名


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes the applicant name always editable during registration modification.
> 
> - In `resources/views/camps/tcamp/form.blade.php`, removed the `@if(isset($isModify) && $isModify) disabled @endif` from the `name` input, leaving it as `required` without conditional disabling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 804385afd098ebdf8a2ffa06bbab7f9de7698a2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->